### PR TITLE
Player projectile - bug fix and streamline

### DIFF
--- a/CEN3031/Assets/Main.unity
+++ b/CEN3031/Assets/Main.unity
@@ -631,7 +631,10 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   speed: 5
-  movement: {x: 0, y: 0}
+  range: 10
+  damage: 1
+  fire_rate: 0.25
+  shot_speed: 10
 --- !u!50 &728306941
 Rigidbody2D:
   serializedVersion: 4
@@ -651,7 +654,7 @@ Rigidbody2D:
   m_Interpolate: 0
   m_SleepingMode: 1
   m_CollisionDetection: 0
-  m_Constraints: 0
+  m_Constraints: 4
 --- !u!61 &728306942
 BoxCollider2D:
   m_ObjectHideFlags: 0
@@ -689,7 +692,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   shotPrefab: {fileID: 4533708081742398, guid: 4bf52df7f637c57469f60a6d222b4b0d, type: 2}
-  shootingRate: 0.15
 --- !u!1 &745068324
 GameObject:
   m_ObjectHideFlags: 0

--- a/CEN3031/Assets/Move.cs
+++ b/CEN3031/Assets/Move.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class Move : MonoBehaviour {
 
     // Object speed
-    public Vector2 speed = new Vector2(10, 10);
+    public Vector2 speed;
 
     // Moving direction
     public Vector2 direction = new Vector2(1, 0);

--- a/CEN3031/Assets/PlayerClass.cs
+++ b/CEN3031/Assets/PlayerClass.cs
@@ -4,10 +4,15 @@ using UnityEngine;
 
 public class PlayerClass : MonoBehaviour
 {
-    
-    private Rigidbody2D rb2d; 
     public float speed;
-    public Vector2 movement = new Vector2(0, 0);
+    public float range;
+    public int damage;
+    public float fire_rate;
+    public float shot_speed;
+
+    private Rigidbody2D rb2d;
+    private Vector2 movement = new Vector2(0, 0);
+
 
     //Player controller script created and used for offloading logic and calculations to testable interface
     public Player_control pctrl = new Player_control();
@@ -36,9 +41,15 @@ public class PlayerClass : MonoBehaviour
         rb2d.MovePosition(rb2d.position + movement * speed * Time.fixedDeltaTime);
 
         // Shooting up
-        if (Input.GetKeyDown(KeyCode.UpArrow))
+        if (Input.GetKey(KeyCode.UpArrow))
         {
             WeaponFire weapon = GetComponent<WeaponFire>();
+            weapon.set_dmg(damage);
+            weapon.set_fire_rate(fire_rate);
+            weapon.set_range(range);
+            weapon.set_shot_speed(shot_speed);
+
+
             if (weapon != null)
             {
                 // false because the player is not an enemy
@@ -47,9 +58,14 @@ public class PlayerClass : MonoBehaviour
         }
 
         // Shooting down
-        if (Input.GetKeyDown(KeyCode.DownArrow))
+        if (Input.GetKey(KeyCode.DownArrow))
         {
             WeaponFire weapon = GetComponent<WeaponFire>();
+            weapon.set_dmg(damage);
+            weapon.set_fire_rate(fire_rate);
+            weapon.set_range(range);
+            weapon.set_shot_speed(shot_speed);
+
             if (weapon != null)
             {
                 // false because the player is not an enemy
@@ -58,9 +74,14 @@ public class PlayerClass : MonoBehaviour
         }
 
         // Shooting right
-        if (Input.GetKeyDown(KeyCode.RightArrow))
+        if (Input.GetKey(KeyCode.RightArrow))
         {
             WeaponFire weapon = GetComponent<WeaponFire>();
+            weapon.set_dmg(damage);
+            weapon.set_fire_rate(fire_rate);
+            weapon.set_range(range);
+            weapon.set_shot_speed(shot_speed);
+
             if (weapon != null)
             {
                 // false because the player is not an enemy
@@ -69,9 +90,14 @@ public class PlayerClass : MonoBehaviour
         }
 
         // Shooting left
-        if (Input.GetKeyDown(KeyCode.LeftArrow))
+        if (Input.GetKey(KeyCode.LeftArrow))
         {
             WeaponFire weapon = GetComponent<WeaponFire>();
+            weapon.set_dmg(damage);
+            weapon.set_fire_rate(fire_rate);
+            weapon.set_range(range);
+            weapon.set_shot_speed(shot_speed);
+
             if (weapon != null)
             {
                 // false because the player is not an enemy

--- a/CEN3031/Assets/Shot.cs
+++ b/CEN3031/Assets/Shot.cs
@@ -4,8 +4,14 @@ using UnityEngine;
 
 public class Shot : MonoBehaviour {
   
+    //How do you get range and speed?
+    //Passing of variables between scripts is difficult
+
     // Damage inflicted
-    public int dmg = 1;
+    public int dmg;
+    public float range;
+    public float shot_speed;
+    
 
     // Projectile damage player or enemies?
     public bool isEnemyShot = false;
@@ -13,7 +19,15 @@ public class Shot : MonoBehaviour {
     void Start()
     {
         // 2 - Limited time to live to avoid any leak
-        Destroy(gameObject, 2); // 2sec
+        Destroy(gameObject, range / shot_speed); // range divided by velocity
+    }
+
+    private void OnTriggerEnter2D(Collider2D collision)
+    {
+        if ((collision.tag == "Enviroment"))
+        {
+            Destroy(gameObject);
+        }
     }
 }
 

--- a/CEN3031/Assets/WeaponFire.cs
+++ b/CEN3031/Assets/WeaponFire.cs
@@ -8,7 +8,31 @@ public class WeaponFire : MonoBehaviour {
     public Transform shotPrefab;
 
     // Cooldown in seconds between two shots
-    public float shootingRate = 0.15f;
+    private float range;
+    private int damage;
+    private float fire_rate;
+    private float shot_speed;
+
+    public void set_range(float range)
+    {
+        this.range = range;
+    }
+
+    public void set_dmg(int damage)
+    {
+        this.damage = damage;
+    }
+
+    public void set_fire_rate(float fire_rate)
+    {
+        this.fire_rate = fire_rate;
+    }
+
+    public void set_shot_speed(float shot_speed)
+    {
+        this.shot_speed = shot_speed;
+    }
+
 
     // 2 - Cooldown
     private float shootCooldown;
@@ -32,16 +56,21 @@ public class WeaponFire : MonoBehaviour {
     {
         if (CanAttack)
         {
-            shootCooldown = shootingRate;
+            shootCooldown = fire_rate;
 
             // Create a new shot
             var shotTransform = Instantiate(shotPrefab) as Transform;
 
             // Assign position
-            shotTransform.position = transform.position;
+            // Position adjusted based on player - also affects enemy
+            shotTransform.position = transform.position + new Vector3(0f, 0.75f, 0f);
 
             // The is enemy property
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();
+            shot.dmg = damage;
+            shot.range = range;
+            shot.shot_speed = shot_speed;
+
             if (shot != null)
             {
                 shot.isEnemyShot = isEnemy;
@@ -49,6 +78,8 @@ public class WeaponFire : MonoBehaviour {
 
             // Make the weapon shot always towards it
             Move move = shotTransform.gameObject.GetComponent<Move>();
+            move.speed = new Vector2(shot_speed, shot_speed);
+
             if (move != null)
             {
                 move.direction = this.transform.up; // towards in 2D space is the right of the sprite
@@ -61,16 +92,20 @@ public class WeaponFire : MonoBehaviour {
     {
         if (CanAttack)
         {
-            shootCooldown = shootingRate;
+            shootCooldown = fire_rate;
 
             // Create a new shot
             var shotTransform = Instantiate(shotPrefab) as Transform;
 
             // Assign position
-            shotTransform.position = transform.position;
+            shotTransform.position = transform.position - new Vector3(0f, 0.75f, 0f);
 
             // The is enemy property
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();
+            shot.dmg = damage;
+            shot.range = range;
+            shot.shot_speed = shot_speed;
+
             if (shot != null)
             {
                 shot.isEnemyShot = isEnemy;
@@ -78,6 +113,8 @@ public class WeaponFire : MonoBehaviour {
 
             // Make the weapon shot always towards it
             Move move = shotTransform.gameObject.GetComponent<Move>();
+            move.speed = new Vector2(shot_speed, shot_speed);
+
             if (move != null)
             {
                 move.direction = -(this.transform.up); // towards in 2D space is the right of the sprite
@@ -90,16 +127,20 @@ public class WeaponFire : MonoBehaviour {
     {
         if (CanAttack)
         {
-            shootCooldown = shootingRate;
+            shootCooldown = fire_rate;
 
             // Create a new shot
             var shotTransform = Instantiate(shotPrefab) as Transform;
 
             // Assign position
-            shotTransform.position = transform.position;
-
+            shotTransform.position = transform.position + new Vector3(0.75f, 0f, 0f);
+        
             // The is enemy property
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();
+            shot.dmg = damage;
+            shot.range = range;
+            shot.shot_speed = shot_speed;
+
             if (shot != null)
             {
                 shot.isEnemyShot = isEnemy;
@@ -107,6 +148,8 @@ public class WeaponFire : MonoBehaviour {
 
             // Make the weapon shot always towards it
             Move move = shotTransform.gameObject.GetComponent<Move>();
+            move.speed = new Vector2(shot_speed, shot_speed);
+
             if (move != null)
             {
                 move.direction = this.transform.right; // towards in 2D space is the right of the sprite
@@ -119,16 +162,20 @@ public class WeaponFire : MonoBehaviour {
     {
         if (CanAttack)
         {
-            shootCooldown = shootingRate;
+            shootCooldown = fire_rate;
 
             // Create a new shot
             var shotTransform = Instantiate(shotPrefab) as Transform;
 
             // Assign position
-            shotTransform.position = transform.position;
+            shotTransform.position = transform.position - new Vector3(0.75f, 0f, 0f);
 
             // The is enemy property
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();
+            shot.dmg = damage;
+            shot.range = range;
+            shot.shot_speed = shot_speed;
+
             if (shot != null)
             {
                 shot.isEnemyShot = isEnemy;
@@ -136,6 +183,8 @@ public class WeaponFire : MonoBehaviour {
 
             // Make the weapon shot always towards it
             Move move = shotTransform.gameObject.GetComponent<Move>();
+            move.speed = new Vector2(shot_speed, shot_speed);
+
             if (move != null)
             {
                 move.direction = -(this.transform.right); // towards in 2D space is the right of the sprite


### PR DESCRIPTION
Implemented projectile collision with enviornment, enabled continuous shooting for held key press, changed origin location of projectile to be outside the player object, and implemented a pipeline for assigning projectile parameters to the player that are passed through weapon, shot, and move classes.

Added destroy event on environmental collision to Shot.cs

Changed KeyPressDown to KeyPress for continuous shooting.

Hard coded vector shift of starting position of the transformation in WeaponFire.cs to have the projectile start just outside of the player object.

Damage, range, shot_speed and fire rate are all parameters now associated with the player object.  These values are passed through projectile pipeline of WeaponFire.cs, Shot.cs, and move.cs so they only need to be assigned as paramters for the player class.   This way can easily tweak these values and potentially adjust them during runtime as a progression system (player upgrades).