### PR TITLE
Fixed Bug in WeaponFire and finished Enemy AI 2

### DIFF
--- a/CEN3031/Assets/WeaponFire.cs
+++ b/CEN3031/Assets/WeaponFire.cs
@@ -72,7 +72,7 @@ public class WeaponFire : MonoBehaviour {
 
             // Assign position
             // Position adjusted based on player - also affects enemy
-            shotTransform.position = transform.position + new Vector3(0f, 0.75f, 0f);
+            shotTransform.position = transform.position + new Vector3(0f, 2f, 0f);
 
             // add values to shot object
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();
@@ -102,7 +102,7 @@ public class WeaponFire : MonoBehaviour {
             var shotTransform = Instantiate(shotPrefab) as Transform;
 
             // Assign position
-            shotTransform.position = transform.position - new Vector3(0f, 0.75f, 0f);
+            shotTransform.position = transform.position - new Vector3(0f, -2f, 0f);
 
             // add values to shot object
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();
@@ -132,7 +132,7 @@ public class WeaponFire : MonoBehaviour {
             var shotTransform = Instantiate(shotPrefab) as Transform;
 
             // Assign position
-            shotTransform.position = transform.position + new Vector3(0.75f, 0f, 0f);
+            shotTransform.position = transform.position + new Vector3(2f, 0f, 0f);
 
             // add values to shot object
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();
@@ -162,7 +162,7 @@ public class WeaponFire : MonoBehaviour {
             var shotTransform = Instantiate(shotPrefab) as Transform;
 
             // Assign position
-            shotTransform.position = transform.position - new Vector3(0.75f, 0f, 0f);
+            shotTransform.position = transform.position - new Vector3(-2f, 0f, 0f);
 
             // add values to shot object
             Shot shot = shotTransform.gameObject.GetComponent<Shot>();


### PR DESCRIPTION
- Fixed bug in WeaponFire with projectiles being spawned in wrong relative locations
- Enemy AI now handles spawning projectiles with relative offsets so that the projectiles appear to be spawned from the enemy's attack, not just from the enemy's center. The projectile_offset_direction variables handle this and allow for easy variability for new enemies